### PR TITLE
chore: add Oxford comma (#351)

### DIFF
--- a/client/components/Features.tsx
+++ b/client/components/Features.tsx
@@ -32,7 +32,7 @@ const Features = () => (
         Use custom domains for your links. Add or remove them for free.
       </FeaturesItem>
       <FeaturesItem title="API" icon="zap">
-        Use the provided API to create, delete and get URLs from anywhere.
+        Use the provided API to create, delete, and get URLs from anywhere.
       </FeaturesItem>
       <FeaturesItem title="Free &amp; open source" icon="heart">
         Completely open source and free. You can host it on your own server.


### PR DESCRIPTION
Previously, the Oxford comma was not being used here. Although a minor change, the addition of an Oxford comma would make it clearer to readers the message that is being conveyed.

Closes #350